### PR TITLE
[#add-multiple-type] Add multiple case to validatetype.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var gulp = require('gulp'),
   boilerplate = require('boilerplate-gulp');
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 exports.dataType = require('./validateDataType');
 exports.model = require('./validateModel');
 exports.operation = require('./validateOperation');

--- a/src/validateDataType.js
+++ b/src/validateDataType.js
@@ -30,8 +30,7 @@ function validateDataType(candidate, dataType, models){
     case 'multiple':
       var errors = [];
       Object.keys(types).forEach(function(key) {
-        dataType.type = types[key];
-        var error = validate.dataType(candidate, dataType ,models);
+        var error = validate.dataType(candidate, {type: types[key]} ,models);
         if (error) {
           errors.push(error);
         }
@@ -42,6 +41,7 @@ function validateDataType(candidate, dataType, models){
       } else {
         return errors;
       }
+      break;
     default:
       // Assumed to be complex model
       var model = models[type];

--- a/src/validateDataType.js
+++ b/src/validateDataType.js
@@ -1,11 +1,16 @@
 'use strict';
 
 var validate = require('./index');
-  
+
 function validateDataType(candidate, dataType, models){
   models = models || {};
-      
   var type = dataType.type || dataType.dataType || dataType.$ref;
+  var types;
+
+  if (Array.isArray(type)) {
+      types = type;
+      type = 'multiple';
+  }
 
   switch(type){
     case 'integer':
@@ -22,6 +27,21 @@ function validateDataType(candidate, dataType, models){
       return validate.primitive.void(candidate);
     case 'File':
       return validate.primitive.file();
+    case 'multiple':
+      var errors = [];
+      Object.keys(types).forEach(function(key) {
+        dataType.type = types[key];
+        var error = validate.dataType(candidate, dataType ,models);
+        if (error) {
+          errors.push(error);
+        }
+      });
+
+      if (errors.length < type.length) {
+        return null;
+      } else {
+        return errors;
+      }
     default:
       // Assumed to be complex model
       var model = models[type];


### PR DESCRIPTION
I add case of multiple for If we want allow multiple type.
e.g. 
If we want allow  both "integer" and "string"

Json

```
type: ['integer', 'string']
```

Yaml

```
type:
  - integer
  - string
```
